### PR TITLE
Added Feature to Save and Like Internships

### DIFF
--- a/Backend/prisma/migrations/20240715222533_add_application_status/migration.sql
+++ b/Backend/prisma/migrations/20240715222533_add_application_status/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[recruiterId]` on the table `Internship` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateTable
+CREATE TABLE "ApplicationStatus" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "internshipId" INTEGER NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'not applied',
+
+    CONSTRAINT "ApplicationStatus_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApplicationStatus_userId_internshipId_key" ON "ApplicationStatus"("userId", "internshipId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Internship_recruiterId_key" ON "Internship"("recruiterId");
+
+-- AddForeignKey
+ALTER TABLE "ApplicationStatus" ADD CONSTRAINT "ApplicationStatus_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ApplicationStatus" ADD CONSTRAINT "ApplicationStatus_internshipId_fkey" FOREIGN KEY ("internshipId") REFERENCES "Internship"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/Backend/prisma/migrations/20240715234150_add_saved_and_liked_internships/migration.sql
+++ b/Backend/prisma/migrations/20240715234150_add_saved_and_liked_internships/migration.sql
@@ -1,0 +1,42 @@
+/*
+  Warnings:
+
+  - You are about to drop the `ApplicationStatus` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ApplicationStatus" DROP CONSTRAINT "ApplicationStatus_internshipId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ApplicationStatus" DROP CONSTRAINT "ApplicationStatus_userId_fkey";
+
+-- DropTable
+DROP TABLE "ApplicationStatus";
+
+-- CreateTable
+CREATE TABLE "UserSavedInternship" (
+    "userId" INTEGER NOT NULL,
+    "internshipId" INTEGER NOT NULL,
+
+    CONSTRAINT "UserSavedInternship_pkey" PRIMARY KEY ("userId","internshipId")
+);
+
+-- CreateTable
+CREATE TABLE "UserLikedInternship" (
+    "userId" INTEGER NOT NULL,
+    "internshipId" INTEGER NOT NULL,
+
+    CONSTRAINT "UserLikedInternship_pkey" PRIMARY KEY ("userId","internshipId")
+);
+
+-- AddForeignKey
+ALTER TABLE "UserSavedInternship" ADD CONSTRAINT "UserSavedInternship_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserSavedInternship" ADD CONSTRAINT "UserSavedInternship_internshipId_fkey" FOREIGN KEY ("internshipId") REFERENCES "Internship"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserLikedInternship" ADD CONSTRAINT "UserLikedInternship_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserLikedInternship" ADD CONSTRAINT "UserLikedInternship_internshipId_fkey" FOREIGN KEY ("internshipId") REFERENCES "Internship"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/Backend/prisma/migrations/20240716200811_a/migration.sql
+++ b/Backend/prisma/migrations/20240716200811_a/migration.sql
@@ -1,0 +1,60 @@
+/*
+  Warnings:
+
+  - You are about to drop the `UserLikedInternship` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `UserSavedInternship` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "UserLikedInternship" DROP CONSTRAINT "UserLikedInternship_internshipId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserLikedInternship" DROP CONSTRAINT "UserLikedInternship_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserSavedInternship" DROP CONSTRAINT "UserSavedInternship_internshipId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserSavedInternship" DROP CONSTRAINT "UserSavedInternship_userId_fkey";
+
+-- DropTable
+DROP TABLE "UserLikedInternship";
+
+-- DropTable
+DROP TABLE "UserSavedInternship";
+
+-- CreateTable
+CREATE TABLE "_usersSavedRelation" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_usersLikedRelation" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_usersSavedRelation_AB_unique" ON "_usersSavedRelation"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_usersSavedRelation_B_index" ON "_usersSavedRelation"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_usersLikedRelation_AB_unique" ON "_usersLikedRelation"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_usersLikedRelation_B_index" ON "_usersLikedRelation"("B");
+
+-- AddForeignKey
+ALTER TABLE "_usersSavedRelation" ADD CONSTRAINT "_usersSavedRelation_A_fkey" FOREIGN KEY ("A") REFERENCES "Internship"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_usersSavedRelation" ADD CONSTRAINT "_usersSavedRelation_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_usersLikedRelation" ADD CONSTRAINT "_usersLikedRelation_A_fkey" FOREIGN KEY ("A") REFERENCES "Internship"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_usersLikedRelation" ADD CONSTRAINT "_usersLikedRelation_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/Backend/prisma/migrations/20240717060934_updated_internship/migration.sql
+++ b/Backend/prisma/migrations/20240717060934_updated_internship/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Internship_recruiterId_key";

--- a/Backend/prisma/schema.prisma
+++ b/Backend/prisma/schema.prisma
@@ -24,6 +24,8 @@ model User {
   technicalSkills     Json
   previousInternships Int?
   notifications       Notification[]
+  savedInternships    Internship[]   @relation("usersSavedRelation")
+  likedInternships    Internship[]   @relation("usersLikedRelation")
 }
 
 model Internship {
@@ -37,8 +39,10 @@ model Internship {
   qualifications String
   url            String
   postedAt       DateTime
-  recruiterId    Int?       @unique
+  recruiterId    Int?
   recruiter      Recruiter? @relation(fields: [recruiterId], references: [id], name: "RecruiterInternships")
+  usersSaved     User[]     @relation("usersSavedRelation")
+  usersLiked     User[]     @relation("usersLikedRelation")
 
   @@unique([title, company])
 }

--- a/Frontend/src/Component/DashBoard/DashBoard.jsx
+++ b/Frontend/src/Component/DashBoard/DashBoard.jsx
@@ -14,7 +14,7 @@ const DashBoard = () => {
     const [savedInternships, setSavedInternships] = useState([]);
     const [likedInternships, setLikedInternships] = useState([]);
     const [displayedInternships, setDisplayedInternships] = useState([]);
-    const [searchTer, setSearchTerm] = useState('');
+    const [searchTerm, setSearchTerm] = useState('');
 
     useEffect(() => {
         const fetchInternships = async () => {
@@ -42,8 +42,8 @@ const DashBoard = () => {
                 });
                 if (response.ok) {
                     const data = await response.json();
-                    setSavedInternships(data.savedInternships.map(internship => internship.id));
-                    setLikedInternships(data.likedInternships.map(internship => internship.id));
+                    setSavedInternships(Array.isArray(data.savedInternships) ? data.savedInternships.map(internship => internship.id) : []);
+                    setLikedInternships(Array.isArray(data.likedInternships) ? data.likedInternships.map(internship => internship.id) : []);
                 } else {
                     console.error('Error fetching user data:', response.statusText);
                 }
@@ -95,29 +95,65 @@ const DashBoard = () => {
         }
     };
 
-    const saveInternship = async (id) => {
+    const toggleSaveInternship = async (id) => {
         try {
-            await fetch(`http://localhost:3001/api/internships/${id}/save`, {
-                method: 'POST',
-                headers: {
-                    'Authorization': `${localStorage.getItem('token')}`
-                }
-            });
-            setSavedInternships([...savedInternships, id]);
+            let response;
+            if (!savedInternships.includes(id)) {
+                response = await fetch(`http://localhost:3001/api/internships/${id}/save`, {
+                    method: 'POST',
+                    headers: {
+                        'Authorization': `${localStorage.getItem('token')}`,
+                        'Content-Type': 'application/json'
+                    }
+                });
+            }
+            else {
+                response = await fetch(`http://localhost:3001/api/internships/${id}/save`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Authorization': `${localStorage.getItem('token')}`,
+                        'Content-Type': 'application/json'
+                    }
+                });
+            }
+            if (response.ok) {
+                const updatedSavedInternships = await response.json();
+                setSavedInternships(Array.isArray(updatedSavedInternships) ? updatedSavedInternships.map(internship => internship.id) : []);
+            } else {
+                console.error('Error saving internship:', response.statusText);
+            }
         } catch (error) {
             console.error('Error saving internship:', error);
         }
     };
 
-    const likeInternship = async (id) => {
+    const toggleLikeInternship = async (id) => {
         try {
-            await fetch(`http://localhost:3001/api/internships/${id}/like`, {
-                method: 'POST',
-                headers: {
-                    'Authorization': `${localStorage.getItem('token')}`
-                }
-            });
-            setLikedInternships([...likedInternships, id]);
+            let response;
+            if (!likedInternships.includes(id)) {
+                response = await fetch(`http://localhost:3001/api/internships/${id}/like`, {
+                    method: 'POST',
+                    headers: {
+                        'Authorization': `${localStorage.getItem('token')}`,
+                        'Content-Type': 'application/json'
+                    }
+                });
+            }
+            else {
+                response = await fetch(`http://localhost:3001/api/internships/${id}/like`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Authorization': `${localStorage.getItem('token')}`,
+                        'Content-Type': 'application/json'
+                    }
+                });
+            }
+            if (response.ok) {
+                const updatedLikedInternships = await response.json();
+                setLikedInternships(Array.isArray(updatedLikedInternships) ? updatedLikedInternships.map(internship => internship.id) : []);
+            } else {
+                console.error('Error liking internship:', response.statusText);
+            }
         } catch (error) {
             console.error('Error liking internship:', error);
         }
@@ -154,13 +190,11 @@ const DashBoard = () => {
                                 <p><strong>Qualifications:</strong> {internship.qualifications}</p>
                                 <a href={internship.url} target="_blank" rel="noopener noreferrer">Apply Here</a>
                                 <div className="icons">
-                                    <div onClick={() => saveInternship(internship.id)}>
-                                        {!isSaved && <i className="fa-regular  fa-beat fa-bookmark"></i>}
-                                        {isSaved && <i className="fa-sharp fa-solid fa-bookmark"></i>}
+                                    <div onClick={() => toggleSaveInternship(internship.id)}>
+                                        {isSaved ? <i className="fa-solid fa-bookmark"></i> : <i className="fa-regular fa-bookmark"></i>}
                                     </div>
-                                    <div onClick={() => likeInternship(internship.id)}>
-                                        {!isLiked && <i className="fa-regular fa-beat fa-thumbs-up"></i>}
-                                        {isLiked && <i className="fa-solid fa-thumbs-up"></i>}
+                                    <div onClick={() => toggleLikeInternship(internship.id)}>
+                                        {isLiked ? <i className="fa-solid fa-thumbs-up"></i> : <i className="fa-regular fa-thumbs-up"></i>}
                                     </div>
                                 </div>
                             </div>

--- a/Frontend/src/Component/Notifications/Notifications.css
+++ b/Frontend/src/Component/Notifications/Notifications.css
@@ -6,40 +6,38 @@ body {
     max-width: 800px;
     margin: 0 auto;
     padding: 20px;
+    text-align: center;
 }
 
 .notifications-container h2 {
-    text-align: center;
     margin-bottom: 20px;
     color: #333;
 }
 
 .notifications-container p {
-    text-align: center;
     color: #777;
 }
 
-.notifications-container ul {
-    list-style-type: none;
-    padding: 0;
-}
-
-.notifications-container li {
+.notification-cards {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 10px;
-    margin-bottom: 10px;
-    background-color: #f9f9f9;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.notification-card {
+    background: #f9f9f9;
     border: 1px solid #ddd;
+    margin: 10px;
+    padding: 15px;
     border-radius: 5px;
+    width: 100%;
 }
 
-.notifications-container li:nth-child(even) {
-    background-color: #f1f1f1;
+.notification-card h3 {
+    margin-top: 0;
 }
 
-.notifications-container button {
+.notification-card button {
     background-color: #007bff;
     color: white;
     border: none;
@@ -48,17 +46,17 @@ body {
     cursor: pointer;
 }
 
-.notifications-container button:hover {
+.notification-card button:hover {
     background-color: #0056b3;
 }
 
 @media (max-width: 600px) {
-    .notifications-container li {
+    .notification-card {
         flex-direction: column;
         align-items: flex-start;
     }
 
-    .notifications-container button {
+    .notification-card button {
         margin-top: 10px;
     }
 }

--- a/Frontend/src/Component/Notifications/Notifications.jsx
+++ b/Frontend/src/Component/Notifications/Notifications.jsx
@@ -27,7 +27,7 @@ const Notifications = () => {
         try {
             const token = localStorage.getItem('token');
             await fetch(`http://localhost:3001/api/notifications/${id}`, {
-                method: 'delete',
+                method: 'DELETE',
                 headers: { Authorization: `${token}` }
             });
             setNotifications(prevNotifications => prevNotifications.filter(n => n.id !== id));
@@ -39,19 +39,20 @@ const Notifications = () => {
     return (
         <>
             <Header />
-            <div>
+            <div className="notifications-container">
                 <h2>Notifications</h2>
                 {notifications.length === 0 ? (
                     <p>No new notifications</p>
                 ) : (
-                    <ul>
+                    <div className="notification-cards">
                         {notifications.map(notification => (
-                            <li key={notification.id}>
-                                {notification.content}
+                            <div key={notification.id} className="notification-card">
+                                <h3>{notification.title}</h3>
+                                <p>{notification.content}</p>
                                 <button onClick={() => markAsRead(notification.id)}>Mark as Read</button>
-                            </li>
+                            </div>
                         ))}
-                    </ul>
+                    </div>
                 )}
             </div>
         </>

--- a/Frontend/src/Component/SavedLikedInternships/SavedLikedInternships.css
+++ b/Frontend/src/Component/SavedLikedInternships/SavedLikedInternships.css
@@ -1,6 +1,6 @@
-.saved-liked-internships {
+/* .saved-liked-internships {
     padding: 20px;
-}
+} */
 
 .main-content {
     padding: 20px;
@@ -29,4 +29,10 @@
 
 .icons .fa-icon:hover {
     color: #007BFF;
+}
+
+.footer-styling {
+    position: fixed;
+    width: 100vw;
+    bottom: 0;
 }

--- a/Frontend/src/Component/SavedLikedInternships/SavedLikedInternships.jsx
+++ b/Frontend/src/Component/SavedLikedInternships/SavedLikedInternships.jsx
@@ -11,17 +11,18 @@ const SavedLikedInternships = ({ type }) => {
     useEffect(() => {
         const fetchInternships = async () => {
             try {
-                const response = await fetch(`http://localhost:3001/api/user`, {
+                const response = await fetch('http://localhost:3001/api/user', {
+                    method: "GET",
                     headers: {
-                        'Authorization': `Bearer ${localStorage.getItem('token')}`
+                        'Authorization': `${localStorage.getItem('token')}`
                     }
                 });
                 if (response.ok) {
                     const data = await response.json();
                     if (type === 'saved') {
-                        setInternships(data.savedInternships);
+                        setInternships(data.savedInternships || []);
                     } else if (type === 'liked') {
-                        setInternships(data.likedInternships);
+                        setInternships(data.likedInternships || []);
                     }
                 } else {
                     console.error('Error fetching internships:', response.statusText);
@@ -53,7 +54,10 @@ const SavedLikedInternships = ({ type }) => {
                     ))}
                 </div>
             </main>
-            <Footer />
+            <div className='footer-styling'>
+                <Footer />
+            </div>
+
         </div>
     );
 };


### PR DESCRIPTION
**Description:**

This pull request introduces a new feature that allows users to save and like internships. The feature includes the following changes:
- API endpoint to save internships (`POST /api/internships/:id/save`)
- API endpoint to like internships (`POST /api/internships/:id/like`)
- Updated Prisma schema to support saved and liked internships relationships
- Inclusion of related `savedInternships` and `likedInternships` in the user response

**Changes:**
- Added new endpoints in `index.js`
- Modified Prisma user model to include `savedInternships` and `likedInternships` relations
- Updated user update logic to return related saved and liked internships
- Added test cases to cover the new functionality

**Test Plan**

**Manual Testing**

**1. Save Internship:**
- Login to the application.
- Navigate to the internships list.
- Save an internship and verify it appears in the user's saved internships list.

**2. Like Internship:**
- Login to the application.
- Navigate to the internships list.
- Like an internship and verify it appears in the user's liked internships list.

**3. Edge Cases:**
- Attempt to save or like the same internship multiple times.
- Attempt to save or like an internship that does not exist.
